### PR TITLE
Will O'Hara sounds as a subcomponent

### DIFF
--- a/ntotsc/language/english/setup.tra
+++ b/ntotsc/language/english/setup.tra
@@ -1211,6 +1211,13 @@ Not Usable By:
  Mage
  Thief~
 
+/* Will O'Hara soundset subcomponent */
+@551 = ~Will O'Hara soundset~
+@552 = ~Requires [Will O'Hara NPC] component~
+@553 = ~Install soundset~
+@554 = ~Do not install soundset~
+@555 = ~Missing sounds will be displayed on in-game chat~
+
 
 /* Strings from DSotSC (k4thos' BGT/EET version) */
 

--- a/ntotsc/language/german/setup.tra
+++ b/ntotsc/language/german/setup.tra
@@ -1282,7 +1282,7 @@ Kann nicht verwendet werden von:
 /* Will O'Hara soundset subcomponent */
 @551 = ~Will O'Hara Geräusche~
 @552 = ~Erfordert [Will O'Hara NPC] Komponente~
-@553 = ~Installieren Geräusche~
+@553 = ~Installieren Geräusche (wenden Sie englische Geräusche an, wenn keine sprachspezifischen Geräusche verfügbar sind)~
 @554 = ~Nicht installieren Geräusche~
 @555 = ~Fehlende Sounds werden im Chat im Spiel angezeigt~
 

--- a/ntotsc/language/german/setup.tra
+++ b/ntotsc/language/german/setup.tra
@@ -1280,10 +1280,10 @@ Kann nicht verwendet werden von:
  Dieben~
 
 /* Will O'Hara soundset subcomponent */
-@551 = ~Will O'Hara Geräusche~
+@551 = ~Will O'Hara Soundset~
 @552 = ~Erfordert [Will O'Hara NPC] Komponente~
-@553 = ~Installieren Geräusche (wenden Sie englische Geräusche an, wenn keine sprachspezifischen Geräusche verfügbar sind)~
-@554 = ~Nicht installieren Geräusche~
+@553 = ~Installieren Soundset (wenden Sie englische Soundset an, wenn keine sprachspezifischen Soundset verfügbar sind)~
+@554 = ~Nicht installieren Soundset~
 @555 = ~Fehlende Sounds werden im Chat im Spiel angezeigt~
 
 

--- a/ntotsc/language/german/setup.tra
+++ b/ntotsc/language/german/setup.tra
@@ -1279,6 +1279,13 @@ Kann nicht verwendet werden von:
  Magiern 
  Dieben~
 
+/* Will O'Hara soundset subcomponent */
+@551 = ~Will O'Hara Geräusche~
+@552 = ~Erfordert [Will O'Hara NPC] Komponente~
+@553 = ~Installieren Geräusche~
+@554 = ~Nicht installieren Geräusche~
+@555 = ~Fehlende Sounds werden im Chat im Spiel angezeigt~
+
 
 /* Strings from DSotSC (k4thos' BGT/EET version) */
 

--- a/ntotsc/language/italian/SETUP.TRA
+++ b/ntotsc/language/italian/SETUP.TRA
@@ -1295,6 +1295,13 @@ Non utilizzabile da:
  Mago
  Ladro~
 
+/* Will O'Hara soundset subcomponent */
+@551 = ~Will O'Hara suoni~
+@552 = ~Richiede [Will O'Hara NPC] componente~
+@553 = ~Installa suoni~
+@554 = ~Non installare suoni~
+@555 = ~I suoni mancanti verranno visualizzati nella chat di gioco~
+
 
 /* Strings from DSotSC (k4thos' BGT/EET version) */
 

--- a/ntotsc/language/italian/SETUP.TRA
+++ b/ntotsc/language/italian/SETUP.TRA
@@ -1298,7 +1298,7 @@ Non utilizzabile da:
 /* Will O'Hara soundset subcomponent */
 @551 = ~Will O'Hara suoni~
 @552 = ~Richiede [Will O'Hara NPC] componente~
-@553 = ~Installa suoni~
+@553 = ~Installa suoni (applica il suoni inglese se i suoni specifici della lingua non sono disponibili)~
 @554 = ~Non installare suoni~
 @555 = ~I suoni mancanti verranno visualizzati nella chat di gioco~
 

--- a/ntotsc/language/polish/setup.tra
+++ b/ntotsc/language/polish/setup.tra
@@ -1,4 +1,4 @@
-@0    = ~NTotSC dla BGT-Weidu, BG:EE i EET przetlumaczyl Kelthar (na podstawie tlumaczenia Evendura) (v.1.0) i Roberciiik (do v3.1.0)~
+@0    = ~NTotSC dla BGT-Weidu, BG:EE i EET przetlumaczyl Kelthar (na podstawie tlumaczenia Evendura) (v.1.0) i Roberciiik (do v3.2.0)~
 
 @1    = ~Zatrute strza³y~
 @2    = ~Te strza³y zosta³y pokryte szybko dzia³aj¹c¹ trucizn¹ roœlinnego pochodzenia.
@@ -1333,6 +1333,14 @@ Nie mo¿e u¿ywaæ:
  Mag
  Z³odziej~
 
+/* Will O'Hara soundset subcomponent */
+@551 = ~UdŸwiêkowienie Willa O'Hara~
+@552 = ~Wymaga komponentu [Will O'Hara NPC]~
+@553 = ~Instaluj odg³osy postaci (aplikuje dŸwiêki angielskie jeœli polskie nie s¹ dostêpne)~
+@554 = ~Nie instaluj og³osów postaci~
+@555 = ~Brakuj¹ce dŸwiêki zostan¹ wyœwietlone w konsoli gry~
+
+
 /* Strings from DSotSC (k4thos' BGT/EET version) */
 
 @1244 = ~Woda œwiêcona~
@@ -1344,7 +1352,7 @@ Nie mo¿e u¿ywaæ:
 PARAMETRY:
 
 Obra¿enia: +2
-Trak0: +2
+TraK0: +2
 Waga: 2
 OpóŸnienie: 3
 Rodzaj bieg³oœci: krótki £uk

--- a/ntotsc/ntotsc.tp2
+++ b/ntotsc/ntotsc.tp2
@@ -2621,27 +2621,41 @@ EXTEND_BOTTOM ~INITGOLV.BCS~ ~ntotsc/will/NTGOLINV.baf~ EVALUATE_BUFFER
 
 EXTEND_BOTTOM ~%Beregost_BCS%.bcs~ ~ntotsc/will/ar3300.baf~ EVALUATE_BUFFER
 
-ACTION_BASH_FOR ~ntotsc/language/english/ogg~ ~^.+\.ogg$~ BEGIN
-	ACTION_IF NOT FILE_EXISTS ~ntotsc/language/%LANGUAGE%/ogg/%BASH_FOR_FILE%~ BEGIN
-		COPY ~%BASH_FOR_FILESPEC%~ ~ntotsc/language/%LANGUAGE%/ogg~
-	END
-END
-
-
 COPY	~ntotsc/base/portraits/%engine%~ ~override~
 COPY	~ntotsc/base/portraits/l~ ~override~
 
-LAF HANDLE_AUDIO
-	STR_VAR
-//	audio_path = EVAL ~ntotsc/language/%LANGUAGE%/ogg~
-	audio_path = EVAL ~ntotsc/language/english/ogg~
-	oggdec_path = ~ntotsc/bin/win32~
-	sox_path = ~ntotsc/bin/osx~
-//	output_path = ~ntotsc/biff~
-	output_path = ~override~
-END
+////////////////////////////////////////////////////////////////////////////
+//
+//  Will O'Hara Soundset subcomponent
+//
+////////////////////////////////////////////////////////////////////////////
 
+BEGIN @553 /* Install soundset */
+	SUBCOMPONENT @551  /* Will O'Hara soundset */
+	REQUIRE_COMPONENT ~ntotsc/NTotSC.tp2~ 6 @552 /* Requires 'Will O'Hara' component */
 
+	// Apply English soundset if language-specific sounds are not available
+	ACTION_BASH_FOR ~ntotsc/language/english/ogg~ ~^will.+\.ogg$~ BEGIN // Only files in "will*.ogg" pattern
+		ACTION_IF NOT FILE_EXISTS ~ntotsc/language/%LANGUAGE%/ogg/%BASH_FOR_FILE%~ BEGIN
+			COPY ~%BASH_FOR_FILESPEC%~ ~ntotsc/language/%LANGUAGE%/ogg~
+		END
+	END
+
+	// Probably should be moved to the end of file if there are more sounds to be converted
+	// or all component-ralated sounds should be copied here to base/ogg directory and then installed
+	LAF HANDLE_AUDIO
+		STR_VAR
+		audio_path = EVAL ~ntotsc/language/%LANGUAGE%/ogg~
+		oggdec_path = ~ntotsc/bin/win32~
+		sox_path = ~ntotsc/bin/osx~
+		output_path = ~override~
+	END
+
+// The same as [Install Component -> No]
+BEGIN @554 /* Do not install soundset */
+	SUBCOMPONENT @551  /* Will O'Hara soundset */
+	REQUIRE_COMPONENT ~ntotsc/NTotSC.tp2~ 6 @552 /* Requires [Will O'Hara NPC] component */
+		PRINT @555 /* Messages for missing sounds will be displayed on in-game chat */
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////
@@ -2655,7 +2669,7 @@ REQUIRE_COMPONENT ~ntotsc/NTotSC.tp2~ 0 @531
 
 
 
-/* additional comrades to Lamalha (AR5000 Valley of the Tombs) */
+/* Additional comrades to Lamalha (AR5000 Valley of the Tombs) */
 
 COPY ~ntotsc/base/cre/ntelka.cre~ ~override~
 	SAY NAME1 @248


### PR DESCRIPTION
- Will O'Hara soundset is now optional subcomponent (reused code - moved under new component)
- Files in pattern "will*.ogg" will be copied to language-specific directory during this step
- Tested on Windows with English and Polish languages with install and skip options.