### PR TITLE
Corrected NPC component reference number

### DIFF
--- a/ntotsc/language/english/setup.tra
+++ b/ntotsc/language/english/setup.tra
@@ -1248,7 +1248,7 @@ Not Usable By:
 /* Will O'Hara soundset subcomponent */
 @551 = ~Will O'Hara Soundset~
 @552 = ~Requires Component [Will O'Hara NPC]~
-@553 = ~Install English Soundset~
+@553 = ~Will O'Hara: Install English Soundset~
 @554 = ~Do not install Soundset~
 @555 = ~Missing sounds will be displayed on in-game text window.~
 /* ------ */

--- a/ntotsc/language/german/setup.tra
+++ b/ntotsc/language/german/setup.tra
@@ -1286,7 +1286,7 @@ Kann nicht verwendet werden von:
 /* Will O'Hara soundset subcomponent */
 @551 = ~Will O'Hara Soundset~
 @552 = ~Erfordert die Komponente [Will O'Hara NPC]~
-@553 = ~Englisches Soundset installieren~
+@553 = ~Will O'Hara: Englisches Soundset installieren~
 @554 = ~Englisches Soundset nicht installieren (keine Sprachausgabe)~
 @555 = ~Sounds werden im Textfenster im Spiel angezeigt (ohne Sprachausgabe)~
 /* ------ */

--- a/ntotsc/language/italian/setup.tra
+++ b/ntotsc/language/italian/setup.tra
@@ -1303,7 +1303,7 @@ Non utilizzabile da:
 /* Will O'Hara soundset subcomponent */
 @551 = ~Will O'Hara Soundset~
 @552 = ~Richiede componente [Will O'Hara NPC].~
-@553 = ~Installare il soundset in inglese~
+@553 = ~Will O'Hara: Installare il soundset in inglese~
 @554 = ~Non installare soundset~
 @555 = ~I suoni mancanti verranno visualizzati nella finestra di testo del gioco.~
 /* ------ */

--- a/ntotsc/language/polish/setup.tra
+++ b/ntotsc/language/polish/setup.tra
@@ -1343,7 +1343,7 @@ Nie mo¿e u¿ywaæ:
 /* Will O'Hara soundset subcomponent */
 @551 = ~UdŸwiêkowienie Willa O'Hara~
 @552 = ~Wymaga komponentu [Will O'Hara NPC]~
-@553 = ~Instaluj odg³osy postaci (aplikuje dŸwiêki angielskie jeœli polskie nie s¹ dostêpne)~
+@553 = ~Will O'Hara: instaluj odg³osy postaci (dŸwiêki angielskie jeœli polskie nie s¹ dostêpne)~
 @554 = ~Nie instaluj og³osów postaci~
 @555 = ~Brakuj¹ce dŸwiêki zostan¹ wyœwietlone w konsoli gry~
 /* ------ */

--- a/ntotsc/language/russian/SETUP.TRA
+++ b/ntotsc/language/russian/SETUP.TRA
@@ -1422,7 +1422,7 @@ THAC0: +2 улучшение
 /* Will O'Hara soundset subcomponent */
 @551 = ~Will O'Hara Soundset~
 @552 = ~Requires Component [Will O'Hara NPC]~
-@553 = ~Install English Soundset~
+@553 = ~Will O'Hara: Install English Soundset~
 @554 = ~Do not install Soundset~
 @555 = ~Missing sounds will be displayed on in-game text window.~
 /* ------ */

--- a/ntotsc/ntotsc.tp2
+++ b/ntotsc/ntotsc.tp2
@@ -2673,8 +2673,7 @@ COPY	~ntotsc/base/portraits/l~ ~override~
 
 BEGIN @553 /* Install soundset */
 DESIGNATED 8 LABEL ~NTotSC_WillSoundset~
-//	SUBCOMPONENT @551  /* Will O'Hara soundset */
-	REQUIRE_COMPONENT ~ntotsc/NTotSC.tp2~ 6 @552 /* Requires 'Will O'Hara' component */
+REQUIRE_COMPONENT ~ntotsc/NTotSC.tp2~ 7 @552 /* Requires 'Will O'Hara' component */
 
 	// Apply English soundset if language-specific sounds are not available
 	ACTION_BASH_FOR ~ntotsc/language/english/ogg~ ~^will.+\.ogg$~ BEGIN // Only files in "will*.ogg" pattern
@@ -2692,13 +2691,6 @@ DESIGNATED 8 LABEL ~NTotSC_WillSoundset~
 		sox_path = ~ntotsc/bin/osx~
 		output_path = ~override~
 	END
-/*
-// The same as [Install Component -> No]
-BEGIN @554 /* Do not install soundset */
-	SUBCOMPONENT @551  /* Will O'Hara soundset */
-	REQUIRE_COMPONENT ~ntotsc/NTotSC.tp2~ 6 @552 /* Requires [Will O'Hara NPC] component */
-		PRINT @555 /* Messages for missing sounds will be displayed on in-game chat */
-*/
 
 //////////////////////////////////////////////////////////////////////////////
 //////////////////////////////////////////////////////////////////////////////


### PR DESCRIPTION
 and removed incorrect /* */ comments clousure in Will O'Hara subcomponent.

When skipped the Svlast's Torment component, you cannot install soundset for NPC (required component numer is incorrect). Also comments */ ending is skipped. 