### PR TITLE
Added unique name to ntplat01 armor.

### DIFF
--- a/ntotsc/language/english/setup.tra
+++ b/ntotsc/language/english/setup.tra
@@ -1347,3 +1347,7 @@ Not Usable By:
 
 /* new in v4.0.0 */
 @55133 = ~Spawn less Monsters depending on Game Difficulty~
+
+/* new in v5.0.0 */
+// #40189 (IWD) [enhancement +1 instead of +3]
+@55134 = ~Shadowed Plate +1~

--- a/ntotsc/language/german/setup.tra
+++ b/ntotsc/language/german/setup.tra
@@ -1330,3 +1330,6 @@ Kann nur verwendet werden von:
 
 /* new in v4.0.0 */
 @55133 = ~Weniger Monster in Abhaengigkeit vom Schweregrad des Spiels~
+
+/* new in v5.0.0 */
+@55134 = ~Schattierte Plattenrüstung +1~

--- a/ntotsc/language/italian/setup.tra
+++ b/ntotsc/language/italian/setup.tra
@@ -1346,3 +1346,6 @@ Non utilizzabile da:
 
 /* new in v4.0.0 */
 @55133 = ~Meno mostri a seconda della difficoltà del gioco~
+
+/* new in v5.0.0 */
+@55134 = ~Piastre d'Ombra +1~

--- a/ntotsc/language/polish/setup.tra
+++ b/ntotsc/language/polish/setup.tra
@@ -1575,3 +1575,6 @@ Nie mo¿e u¿ywaæ:
 
 /* new in v4.0.0 */
 @55133 = ~Przywoluje mniej potworow w zaleznosci od poziomu trudnosci gry~
+
+/* new in v5.0.0 */
+@55134 = ~Cienista zbroja p³ytowa +1~

--- a/ntotsc/language/russian/SETUP.TRA
+++ b/ntotsc/language/russian/SETUP.TRA
@@ -1467,3 +1467,6 @@ THAC0: +2 улучшение
 
 /* new in v4.0.0 */
 @55133 = ~Spawn less Monsters depending on Game Difficulty~
+
+/* new in v5.0.0 */
+@55134 = ~Теневые латы +1~

--- a/ntotsc/ntotsc.tp2
+++ b/ntotsc/ntotsc.tp2
@@ -594,6 +594,7 @@ COPY ~ntotsc/base/itm/ntpblet1.itm~ ~override/ntpblet7.itm~
 	SAY DESC @517
 
 COPY ~ntotsc/base/itm/ntplat01.itm~ ~override~
+	SAY NAME2 @55134
 	SAY DESC @141
 
 COPY ~ntotsc/base/itm/ntplat02.itm~ ~override~


### PR DESCRIPTION
There is no longer "Plate mail +1" in the EE stringrefs, so the name of this armor should be unique. Previously it used "Fallorain armor +1" name!

Armor is based on IWD shadowed plate, so I used IWD name for all languages.  