### PR TITLE
Added missing description for candle item.

### DIFF
--- a/ntotsc/language/english/setup.tra
+++ b/ntotsc/language/english/setup.tra
@@ -1351,3 +1351,8 @@ Not Usable By:
 /* new in v5.0.0 */
 // #40189 (IWD) [enhancement +1 instead of +3]
 @55134 = ~Shadowed Plate +1~
+@55135 = ~A candle is an ignitable wick embedded in wax, or another flammable solid substance such as tallow. Candles are common source of light.
+
+STATISTICS:
+
+Weight: 1~

--- a/ntotsc/language/german/setup.tra
+++ b/ntotsc/language/german/setup.tra
@@ -1333,3 +1333,8 @@ Kann nur verwendet werden von:
 
 /* new in v5.0.0 */
 @55134 = ~Schattierte Plattenrüstung +1~
+@55135 = ~A candle is an ignitable wick embedded in wax, or another flammable solid substance such as tallow. Candles are common source of light.
+
+STATISTICS:
+
+Weight: 1~

--- a/ntotsc/language/italian/setup.tra
+++ b/ntotsc/language/italian/setup.tra
@@ -1349,3 +1349,8 @@ Non utilizzabile da:
 
 /* new in v5.0.0 */
 @55134 = ~Piastre d'Ombra +1~
+@55135 = ~A candle is an ignitable wick embedded in wax, or another flammable solid substance such as tallow. Candles are common source of light.
+
+STATISTICS:
+
+Weight: 1~

--- a/ntotsc/language/polish/setup.tra
+++ b/ntotsc/language/polish/setup.tra
@@ -1578,3 +1578,8 @@ Nie mo¿e u¿ywaæ:
 
 /* new in v5.0.0 */
 @55134 = ~Cienista zbroja p³ytowa +1~
+@55135 = ~Œwieca jest powszechnym Ÿród³em œwiat³a i zazwyczaj wykonuje siê j¹ z wosku pszczelego uformowanego w walec, wewn¹trz którego, przez ca³¹ d³ugoœæ, umieszczony jest knot. Ze wzglêdu na wysok¹ cenê wosku, biedniejsi korzystaj¹ ze œwiec wykonanych z tañszego t³uszczu zwierzêcego.
+
+PARAMETRY:
+
+Waga: 1~

--- a/ntotsc/language/russian/SETUP.TRA
+++ b/ntotsc/language/russian/SETUP.TRA
@@ -1470,3 +1470,8 @@ THAC0: +2 улучшение
 
 /* new in v5.0.0 */
 @55134 = ~Теневые латы +1~
+@55135 = ~A candle is an ignitable wick embedded in wax, or another flammable solid substance such as tallow. Candles are common source of light.
+
+STATISTICS:
+
+Weight: 1~

--- a/ntotsc/ntotsc.tp2
+++ b/ntotsc/ntotsc.tp2
@@ -701,6 +701,12 @@ COPY ~ntotsc/base/itm/nthellsw.itm~ ~override~ //fire salamander weapon
 
 COPY ~ntotsc/base/itm/nostring~ ~override~
 
+/* Edited items from base game */
+
+// Missing description of Ordolath's candle
+COPY_EXISTING ~misc74.itm~ ~override~
+	SAY UNIDENTIFIED_DESC @55135
+	SAY DESC @55135
 
 /* Items from DsotSC */
 


### PR DESCRIPTION
Candle item (misc74) has no description, it is blank in-game. Added general description.